### PR TITLE
Database for creation, user login created and storage of data related to the game

### DIFF
--- a/app/controllers/api/v1/game_data_controller.rb
+++ b/app/controllers/api/v1/game_data_controller.rb
@@ -1,0 +1,23 @@
+class Api::V1::GameDataController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    data = GameData.new(game_data_params.merge(user: current_user))
+    if data.save
+      head :ok
+    else
+      render json: { error: data.errors.full_messages }
+    end
+  end
+
+  def index
+    collection = current_user.game_data
+    render json: { entries: collection }
+  end
+
+  private
+
+  def game_data_params
+    params.require(:game_data).permit!
+  end
+end

--- a/app/models/game_data.rb
+++ b/app/models/game_data.rb
@@ -1,0 +1,3 @@
+class GameData < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
           :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
+  has_many :game_data, class_name: 'GameData'
+
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
     namespace :v0 do
       resources :pings, only: [:index], constraints: { format: 'json' }
     end
-    namespace :v1 do
+    namespace :v1, defaults: { format: :json } do
+      resources :game_data, only: [:create, :index]
     end
   end
 end

--- a/db/migrate/20200924184816_create_performance_data.rb
+++ b/db/migrate/20200924184816_create_performance_data.rb
@@ -1,0 +1,11 @@
+class CreatePerformanceData < ActiveRecord::Migration[6.0]
+  def change
+    execute "CREATE EXTENSION IF NOT EXISTS hstore"
+    create_table :performance_data do |t|
+      t.references :user, index: true, foreign_key: true
+      t.hstore :data
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20200924190926_create_game_data.rb
+++ b/db/migrate/20200924190926_create_game_data.rb
@@ -1,0 +1,11 @@
+class CreateGameData < ActiveRecord::Migration[6.0]
+  def change
+    execute "CREATE EXTENSION IF NOT EXISTS hstore"
+    create_table :game_data do |t|
+      t.references :user, index: true, foreign_key: true
+      t.hstore :data
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_174025) do
+ActiveRecord::Schema.define(version: 2020_09_24_190926) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "hstore"
   enable_extension "plpgsql"
+
+  create_table "game_data", force: :cascade do |t|
+    t.bigint "user_id"
+    t.hstore "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_game_data_on_user_id"
+  end
+
+  create_table "performance_data", force: :cascade do |t|
+    t.bigint "user_id"
+    t.hstore "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_performance_data_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -43,4 +60,6 @@ ActiveRecord::Schema.define(version: 2020_09_24_174025) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "game_data", "users"
+  add_foreign_key "performance_data", "users"
 end

--- a/spec/factories/game_data.rb
+++ b/spec/factories/game_data.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :game_data, class: 'GameData' do
+    user 
+    data { "" }
+  end
+end

--- a/spec/models/game_data_spec.rb
+++ b/spec/models/game_data_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe GameData, type: :model do
+  describe 'Database table' do
+    it { is_expected.to have_db_column :data }
+  end
+
+  describe 'Relations' do
+    it { is_expected.to belong_to :user }
+  end
+
+  describe 'Factory' do
+    it 'should have valid Factory' do
+      expect(create(:game_data)).to be_valid
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,4 +30,7 @@ RSpec.describe User, type: :model do
       end
     end
   end
+  describe 'Relations' do
+    it { is_expected.to have_many :game_data }
+  end
 end

--- a/spec/request/api/v1/game_data_spec.rb
+++ b/spec/request/api/v1/game_data_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Api::V1::GameDataController, type: :request do
+  let(:user) { create(:user) }
+  let(:credentials) { user.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: "application/json" }.merge!(credentials) }
+
+  describe "POST /api/v1/game_data" do
+    before do
+      post "/api/v1/game_data",
+           params: {
+             game_data: {
+               data: { message: "Wins" },
+             },
+           },
+           headers: headers
+    end
+
+    it "returns a 200 response status" do
+      expect(response).to have_http_status 200
+    end
+
+    it "successfully creates a data entry" do
+      entry = GameData.last
+      expect(entry.data).to eq "message" => "Wins"
+    end
+  end
+  describe "GET /api/v1/game_data" do
+    let!(:existing_entries) do
+      4.times do
+        create(:game_data,
+               data: { message: "Wins" },
+               user: user)
+      end
+    end
+
+    before do
+      get "/api/v1/game_data", headers: headers
+    end
+
+    it "returns a 200 response status" do
+      expect(response).to have_http_status 200
+    end
+
+    it "returns a collection of performance data" do
+      expect(response_json["entries"].count).to eq 4
+    end
+  end
+end


### PR DESCRIPTION
## Contains:
- Add a way to store historical data for each user.
- Add hstore as a datatype.
- Add a new relationship has_many :game_data in user model.
- Tests for the Game data model.
- Config factoryBot por GameData
- Create a controller to save data and add a create method. 
- Create a new route :create and add a format json as default.
- Witelist all params contained on the :game_data key and update the create method to use them.
- Asign a user to the created entry. 
- Add tests where FactoryBot create a user and send user credentials, created with DeviseTokenAuth, with the request in headers. 
- Add an index method to the routes.

